### PR TITLE
fix: ios memory leak and gradle build error

### DIFF
--- a/DynamicFonts.m
+++ b/DynamicFonts.m
@@ -17,7 +17,7 @@ RCT_EXPORT_MODULE();
 - (void) loadFontWithData:(CGDataProviderRef) fontDataProvider callback:(RCTResponseSenderBlock)callback
 {
   CGFontRef newFont = CGFontCreateWithDataProvider(fontDataProvider);
-  NSString *newFontName = (__bridge NSString *)CGFontCopyPostScriptName(newFont);
+  NSString *newFontName = (__bridge_transfer NSString *)CGFontCopyPostScriptName(newFont);
 
   UIFont* font = [UIFont fontWithName:newFontName size:16];
   if (font != nil) {
@@ -31,7 +31,7 @@ RCT_EXPORT_MODULE();
     CFStringRef errorDescription = CFErrorCopyDescription(error);
     NSLog(@"Failed to register font: %@", errorDescription);
 
-    callback(@[@"Failed to register font: %@", (__bridge NSString *)errorDescription]);
+    callback(@[@"Failed to register font: %@", (__bridge_transfer NSString *)errorDescription]);
   
     CFRelease(errorDescription);
     CGFontRelease(newFont);

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }
-

--- a/package.json
+++ b/package.json
@@ -1,16 +1,15 @@
 {
-  "name": "react-native-dynamic-fonts",
+  "name": "@brandingbrand/react-native-dynamic-fonts",
   "main": "index.js",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "React Native Dynamic Fonts",
   "nativePackage": true,
   "license": "MIT",
-  "url": "https://github.com/eVisit/react-native-dynamic-fonts",
-  "email": "tech@evisit.com",
+  "url": "https://github.com/brandingbrand/react-native-dynamic-fonts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/eVisit/react-native-dynamic-fonts.git"
+    "url": "https://github.com/brandingbrand/react-native-dynamic-fonts.git"
   },
-  "author": "eVisit (Wyatt Greenway)",
+  "author": "Branding Brand LLC",
   "dependencies": {}
 }


### PR DESCRIPTION
This incorporates two fixes that we've previously resolved with patches in our projects:

Fix #1: Implementation of the following open PR in the main project to fix an iOS memory leak: https://github.com/eVisit/react-native-dynamic-fonts/pull/21

Fix #2: Implementation of the following suggested fix in the main project's issues to support Gradle 7: https://github.com/eVisit/react-native-dynamic-fonts/issues/20