### PR TITLE
fix: Illegal callback invocation from native module

### DIFF
--- a/android/src/main/java/org/th317erd/react/DynamicFontsModule.java
+++ b/android/src/main/java/org/th317erd/react/DynamicFontsModule.java
@@ -61,18 +61,13 @@ class DynamicFontsModule extends ReactContextBaseJavaModule {
     File f = new File(filePath);
 
     if (f.exists() && f.canRead()) {
-      boolean wasLoaded = false;
       try {
         Typeface typeface = Typeface.createFromFile(f);
         //Cache the font for react
         ReactFontManager.getInstance().setTypeface(name, typeface.getStyle(), typeface);
-        wasLoaded = true;
+        callback.invoke(null, name);
       } catch (Throwable e) {
         callback.invoke(e.getMessage());
-      } finally {
-        if (wasLoaded) {
-          callback.invoke(null, name);
-        }
       }
     } else {
       callback.invoke("invalid file");
@@ -150,10 +145,9 @@ class DynamicFontsModule extends ReactContextBaseJavaModule {
       ReactFontManager.getInstance().setTypeface(name, typeface.getStyle(), typeface);
 
       cacheFile.delete();
+      callback.invoke(null, name);
     } catch(Exception e) {
       callback.invoke(e.getMessage());
-    } finally {
-      callback.invoke(null, name);
     }
   }
 }


### PR DESCRIPTION
[Ticket](https://brandingbrand.atlassian.net/browse/REP-1142)

## Description

Addressed the issue reported in this Sentry logs for the Represent project: https://branding-brand.sentry.io/issues/6995903605/?project=4508649674571776&query=is%3Aunresolved%20level%3A%EF%80%8DContains%EF%80%8Dfatal%20release%3A%5Bcom.vennapps.representclo%4021.0.4%2Ccom.vennapps.representclo%4021.0.4%2B210014%2Ccom.vennapps.representclo%4021.0.4%2B2%5D&referrer=issue-stream
(Illegal callback invocation from native module. This callback type only permits a single invocation from native code.)